### PR TITLE
feat: a plugin to produce a channel based on a playlist txt file

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -14,6 +14,7 @@ The following plugins are available.
 | Demo   | Random selection from a pre-defined static list of assets |
 | ScheduleService | Fetches schedule and channels from an [Eyevinn Schedule Service](https://github.com/Eyevinn/schedule-service) |
 | Loop | Produce a channel with a single VOD on loop |
+| Playlist | Produce a channel based on a playlist txt file |
 
 ## Demo Plugin Options
 
@@ -29,3 +30,8 @@ The following plugins are available.
 - `LOOP_CHANNEL_NAME`: The name of the channel (default `loop`)
 
 Channel with the HLS VOD to loop is then available at `/channels/loop/master.m3u8`
+
+## Playlist Plugin Options
+
+- `PLAYLIST_URL`: URL to the playlist txt file. A txt file where each line contains a URL to a HLS VOD ([example](https://testcontent.eyevinn.technology/fast/fast-playlist.txt))
+- `PLAYLIST_CHANNEL_NAME`: The name of the channel (default `playlist`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eyevinn/schedule-service-adapter": "^0.3.3",
         "eyevinn-channel-engine": "^3.4.3",
         "finalhandler": "^1.2.0",
+        "node-fetch": "^2.6.5",
         "serve-static": "^1.15.0"
       },
       "devDependencies": {
@@ -4076,22 +4077,14 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -8530,9 +8523,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@eyevinn/schedule-service-adapter": "^0.3.3",
     "eyevinn-channel-engine": "^3.4.3",
     "finalhandler": "^1.2.0",
+    "node-fetch": "^2.6.5",
     "serve-static": "^1.15.0"
   }
 }

--- a/src/plugin_factory.ts
+++ b/src/plugin_factory.ts
@@ -2,6 +2,7 @@ import { DemoPlugin } from "./plugins/plugin_demo";
 import { PluginInterface } from "./plugins/plugin_interface";
 import { ScheduleServicePlugin } from "./plugins/plugin_schedule_service";
 import { LoopPlugin } from "./plugins/plugin_loop";
+import { PlaylistPlugin } from "./plugins/plugin_playlist";
 
 function create<T extends PluginInterface>(c: { new(): T }): T {
   return new c();  
@@ -15,6 +16,8 @@ export function PluginFactory(pluginName: string) {
       return create(ScheduleServicePlugin);
     case 'Loop':
       return create(LoopPlugin);
+    case 'Playlist':
+      return create(PlaylistPlugin);
     default:
       throw new Error(`Plugin ${pluginName} is not available`);
   }

--- a/src/plugins/plugin_loop.ts
+++ b/src/plugins/plugin_loop.ts
@@ -42,7 +42,7 @@ class LoopChannelManager implements IChannelManager {
 
   _getProfile(): ChannelProfile[] {
     return [
-      { bw: 8134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1920, 1280] },
+      { bw: 8134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1920, 1080] },
       { bw: 6134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1280, 720] },
       { bw: 4134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1024, 458] },
       { bw: 2323000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [640, 286] },

--- a/src/plugins/plugin_playlist.ts
+++ b/src/plugins/plugin_playlist.ts
@@ -1,0 +1,105 @@
+import { IAssetManager, IChannelManager, 
+  VodRequest, VodResponse, 
+  Channel, ChannelProfile, IStreamSwitchManager 
+} from "eyevinn-channel-engine";
+import fetch from "node-fetch";
+
+import { BasePlugin, PluginInterface } from "./plugin_interface";
+
+class PlaylistAssetManager implements IAssetManager {
+  private playlistUrl: URL;
+  private playlist: URL[];
+  private playlistPosition: number;
+
+  constructor(playlistUrl: URL) {
+    this.playlistUrl = playlistUrl;
+    this.playlist = undefined;
+    this.playlistPosition = -1;
+  }
+
+  async getNextVod(vodRequest: VodRequest): Promise<VodResponse> {
+    let vodResponse = {
+      id: "-1",
+      title: "placeholder",
+      uri: "https://lab.cdn.eyevinn.technology/sto-slate.mp4/manifest.m3u"
+    };
+    try {
+      if (!this.playlist) {
+        await this._updatePlaylist();
+      }
+      if (this.playlistPosition !== -1) {
+        vodResponse = {
+          id: `${this.playlistPosition}`,
+          title: `Item ${this.playlistPosition}`,
+          uri: this.playlist[this.playlistPosition].toString(),
+        };
+        this.playlistPosition++;
+        if (this.playlistPosition > this.playlist.length - 1) {
+          this.playlistPosition = 0;
+        }
+      }
+    } catch (e) {
+      console.log(e);
+    }
+    return vodResponse;
+  }
+
+  private async _updatePlaylist() {
+    console.log("Fetching playlist from " + this.playlistUrl);
+    const response = await fetch(this.playlistUrl.toString());
+    if (response.ok) {
+      const body = await response.text();
+      this.playlist = body.split(/\r?\n/).filter(l => l !== '').map(l => new URL(l.trim()));
+      this.playlistPosition = 0;
+    }
+  }
+}
+
+class PlaylistChannelManager implements IChannelManager {
+  private channelId: string;
+
+  constructor(channelId: string) {
+    this.channelId = channelId;
+    console.log(`Playlist channel available at /channels/${this.channelId}/master.m3u8`);
+  }
+
+  getChannels(): Channel[] {
+    const channelList = [
+      {
+        id: this.channelId,
+        profile: this._getProfile()
+      }
+    ];
+    return channelList;
+  }
+
+  _getProfile(): ChannelProfile[] {
+    return [
+      { bw: 8134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1920, 1080] },
+      { bw: 6134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1280, 720] },
+      { bw: 4134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1024, 458] },
+      { bw: 2323000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [640, 286] },
+      { bw: 1313000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [480, 214] },
+    ];
+  }
+}
+
+export class PlaylistPlugin extends BasePlugin implements PluginInterface  {
+  constructor() {
+    super('Playlist');
+  }
+  
+  newAssetManager(): IAssetManager {
+    const playlistUrl = process.env.PLAYLIST_URL ? new URL(process.env.PLAYLIST_URL) 
+      : new URL("https://testcontent.eyevinn.technology/fast/fast-playlist.txt");
+    return new PlaylistAssetManager(playlistUrl);
+  }
+
+  newChannelManager(): IChannelManager {
+    return new PlaylistChannelManager(process.env.PLAYLIST_CHANNEL_NAME ? process.env.PLAYLIST_CHANNEL_NAME : "playlist");
+  }
+
+  newStreamSwitchManager(): IStreamSwitchManager {
+    return undefined;
+  }
+}


### PR DESCRIPTION
This PR adds the plugin `Playlist` that can be used to produce a channel based on a playlist txt file. A playlist txt file where each line contains a URL to an HLS VOD, for example:

```
https://lab.cdn.eyevinn.technology/NO_TIME_TO_DIE_short_Trailer_2021.mp4/manifest.m3u8
https://lab.cdn.eyevinn.technology/THE_GRAND_BUDAPEST_HOTEL_Trailer_2014.mp4/manifest.m3u8
https://lab.cdn.eyevinn.technology/BAAHUBALI_3_Trailer_2021.mp4/manifest.m3u8
https://lab.cdn.eyevinn.technology/OWL_MVP_2021.mp4/manifest.m3u8
```