### PR TITLE
fix: schedule service channels with demuxed audio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - schedule-service
     image: eyevinntechnology/fast-engine
     environment:
+      - OPTS_USE_DEMUXED_AUDIO=false
       - FAST_PLUGIN=ScheduleService
       - SCHEDULE_SERVICE_API_URL=http://schedule-service:8080/api/v1
       - DEBUG=schedule-service-*

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ A channel based on this playlist is then available at `http://localhost:8000/cha
 To spin up a Schedule Service and FAST Channel Engine.
 
 ```bash
-curl -SL https://github.com/Eyevinn/docker-fast/releases/download/v0.2.0/docker-compose.yml | docker-compose -f - up
+curl -SL https://github.com/Eyevinn/docker-fast/releases/download/v1.1.1/docker-compose.yml | docker-compose -f - up
 ```
 
 Running this command above it will spin up three Docker containers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eyevinn/schedule-service-adapter": "^0.3.3",
+        "@eyevinn/schedule-service-adapter": "^0.4.1",
         "eyevinn-channel-engine": "4.0.0",
         "finalhandler": "^1.2.0",
         "node-fetch": "^2.6.5",
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@eyevinn/schedule-service-adapter": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eyevinn/schedule-service-adapter/-/schedule-service-adapter-0.3.3.tgz",
-      "integrity": "sha512-n1/MmbQO2vSkjHoQQtubEyq3Qx4r/YobrsQJHeTo6lIXmwBX2q8ytcu701Zt4Uc845Qki10rItG1reMyerwsoQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eyevinn/schedule-service-adapter/-/schedule-service-adapter-0.4.1.tgz",
+      "integrity": "sha512-SZXuYlpNMZi8npHazyIo7VuqK/eYUnrR7hUTm4VMtMhUcSkcYt9fr47tnZVnDdc1ZfRA3NfNmAWOFd5vly3/UQ==",
       "dependencies": {
         "dayjs": "^1.10.7",
         "debug": "^4.3.2",
@@ -5699,9 +5699,9 @@
       }
     },
     "@eyevinn/schedule-service-adapter": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eyevinn/schedule-service-adapter/-/schedule-service-adapter-0.3.3.tgz",
-      "integrity": "sha512-n1/MmbQO2vSkjHoQQtubEyq3Qx4r/YobrsQJHeTo6lIXmwBX2q8ytcu701Zt4Uc845Qki10rItG1reMyerwsoQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eyevinn/schedule-service-adapter/-/schedule-service-adapter-0.4.1.tgz",
+      "integrity": "sha512-SZXuYlpNMZi8npHazyIo7VuqK/eYUnrR7hUTm4VMtMhUcSkcYt9fr47tnZVnDdc1ZfRA3NfNmAWOFd5vly3/UQ==",
       "requires": {
         "dayjs": "^1.10.7",
         "debug": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@eyevinn/schedule-service-adapter": "^0.3.3",
+    "@eyevinn/schedule-service-adapter": "^0.4.1",
     "eyevinn-channel-engine": "4.0.0",
     "finalhandler": "^1.2.0",
     "node-fetch": "^2.6.5",

--- a/src/plugins/plugin_schedule_service.ts
+++ b/src/plugins/plugin_schedule_service.ts
@@ -56,7 +56,8 @@ export class ScheduleServicePlugin extends BasePlugin implements PluginInterface
     return new AdapterAssetManager(this.adapterChannelManager);
   }
 
-  newChannelManager(): IChannelManager {
+  newChannelManager(useDemuxedAudio: boolean): IChannelManager {
+    this.adapterChannelManager.setUseDemuxedAudio(useDemuxedAudio);
     return this.adapterChannelManager;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ const engine = new ChannelEngine(plugin.newAssetManager(), {
   heartbeat,
   defaultSlateUri,
   useDemuxedAudio,
+  alwaysNewSegments: true,
   channelManager: plugin.newChannelManager(useDemuxedAudio),
   streamSwitchManager: plugin.newStreamSwitchManager(),
 });


### PR DESCRIPTION
This PR handles the scenario where Eyevinn Schedule service has some channels with muxed audio and some channels with demuxed audio. If demuxed audio is enabled (by default) it will filter out all channels in the schedule service that does not have demuxed audio.