### PR TITLE
feat: support for channel presets and advanced audio

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,23 @@ The following environment variables can be set:
 - `OPTS_HEARTBEAT_URL`: Heartbeat url (default: `/`).
 - `OPTS_STREAM_ORDER`: Stream order as comma separated list of heights (default: `"458,1080,720,286,214"`)
 - `OPTS_VIDEO_STREAMS`: Override video profile using a comma separated list of resolution and bandwidth tupels. For example: `-e OPTS_VIDEO_STREAMS="416x234:324586,640x360:471661"`
+- `OPTS_LANG_LIST`: Comma separated list of languages, e.g. (`"en,ja"`). First one is defined to be default
+- `OPTS_CHANNEL_PRESET`: Channel profile based on presets:
+  - `DD`: Sterao (2) and Dolby Digital (6)
+  - `ATMOS`: Stereo (2) and Dolby Atmos track (16) 
+
+### Advanced Audio
+
+Example of Sol Levante in Dolby Atmos audio:
+
+```
+docker run -p 8000:8000 \
+  -e FAST_PLUGIN=Loop \
+  -e LOOP_VOD_URL=https://testcontent.eyevinn.technology/dolby/index.m3u8 \
+  -e OPTS_CHANNEL_PRESET=ATMOS \
+  -e OPTS_LANG_LIST=ja,en \
+  eyevinntechnology/fast-engine
+```
 
 ### Multiview
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/schedule-service-adapter": "^0.4.1",
-        "eyevinn-channel-engine": "4.0.6",
+        "eyevinn-channel-engine": "4.0.8",
         "finalhandler": "^1.2.0",
         "node-fetch": "^2.6.5",
         "serve-static": "^1.15.0"
@@ -156,14 +156,22 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.2.1.tgz",
-      "integrity": "sha512-gj0ycvNP/bnXZKd3V8snMUXv0b98KYVS2FwQ65ybdf8+QZP88Uzfv8ZuFy1M/R1vqGiYfaYpPC3y6P69DMmjgg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.3.tgz",
+      "integrity": "sha512-Tjx08+E/mLNhCWokAqpRQDCf4TaX12zG/W/7FkUt0ZgwPUA/XQn29yWusmsruVjED1Ugh+uxhlwL9nlQmdHSWQ==",
       "dependencies": {
-        "@eyevinn/m3u8": "^0.5.3",
+        "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/@eyevinn/hls-vodtolive/node_modules/@eyevinn/m3u8": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
+      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
+      "dependencies": {
+        "chunked-stream": "~0.0.2"
       }
     },
     "node_modules/@eyevinn/hls-vodtolive/node_modules/debug": {
@@ -2612,13 +2620,13 @@
       ]
     },
     "node_modules/eyevinn-channel-engine": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.0.6.tgz",
-      "integrity": "sha512-+be9NYEiuvRrYbMjzB6RJG/P7n9wKJMp/VkImR6vxeBp4zDzynNYtVoIjIaYqygAmPezd7uzIuI4u6MzBKlR/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.0.8.tgz",
+      "integrity": "sha512-uBNBlW6arOpnsl6mjSloqV3DdXS9NeoSABi/MPQgnATc0sxj7S62YRzLMJgQKBX6dheG2UTktrbUj1P3xnKvuA==",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.2.0",
-        "@eyevinn/hls-vodtolive": "^2.2.1",
+        "@eyevinn/hls-vodtolive": "^2.3.3",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -5665,16 +5673,24 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.2.1.tgz",
-      "integrity": "sha512-gj0ycvNP/bnXZKd3V8snMUXv0b98KYVS2FwQ65ybdf8+QZP88Uzfv8ZuFy1M/R1vqGiYfaYpPC3y6P69DMmjgg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.3.tgz",
+      "integrity": "sha512-Tjx08+E/mLNhCWokAqpRQDCf4TaX12zG/W/7FkUt0ZgwPUA/XQn29yWusmsruVjED1Ugh+uxhlwL9nlQmdHSWQ==",
       "requires": {
-        "@eyevinn/m3u8": "^0.5.3",
+        "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.7"
       },
       "dependencies": {
+        "@eyevinn/m3u8": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
+          "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
+          "requires": {
+            "chunked-stream": "~0.0.2"
+          }
+        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -7393,13 +7409,13 @@
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
     "eyevinn-channel-engine": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.0.6.tgz",
-      "integrity": "sha512-+be9NYEiuvRrYbMjzB6RJG/P7n9wKJMp/VkImR6vxeBp4zDzynNYtVoIjIaYqygAmPezd7uzIuI4u6MzBKlR/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.0.8.tgz",
+      "integrity": "sha512-uBNBlW6arOpnsl6mjSloqV3DdXS9NeoSABi/MPQgnATc0sxj7S62YRzLMJgQKBX6dheG2UTktrbUj1P3xnKvuA==",
       "requires": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.2.0",
-        "@eyevinn/hls-vodtolive": "^2.2.1",
+        "@eyevinn/hls-vodtolive": "^2.3.3",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@eyevinn/schedule-service-adapter": "^0.4.1",
-    "eyevinn-channel-engine": "4.0.6",
+    "eyevinn-channel-engine": "4.0.8",
     "finalhandler": "^1.2.0",
     "node-fetch": "^2.6.5",
     "serve-static": "^1.15.0"

--- a/src/plugins/interface.ts
+++ b/src/plugins/interface.ts
@@ -17,3 +17,9 @@ export class BasePlugin {
     return this.pluginName;
   }
 }
+
+export interface Language {
+  language: string;
+  name: string;
+  default: boolean;
+}

--- a/src/plugins/utils.ts
+++ b/src/plugins/utils.ts
@@ -1,4 +1,7 @@
-const DEFAULT_VIDEO_STREAMS = [
+import { AudioTracks, ChannelProfile } from "eyevinn-channel-engine";
+import { Language } from "./interface";
+
+const DEFAULT_VIDEO_STREAMS: ChannelProfile[] = [
   { bw: 324586, codecs: "avc1.64000D,mp4a.40.2", resolution: [416, 234] },
   { bw: 471661, codecs: "avc1.64001E,mp4a.40.2", resolution: [640, 360] },
   { bw: 584829, codecs: "avc1.64001E,mp4a.40.2", resolution: [768, 432] },
@@ -7,7 +10,42 @@ const DEFAULT_VIDEO_STREAMS = [
   { bw: 9602303, codecs: "avc1.640028,mp4a.40.2", resolution: [1920, 1080] },
 ];
 
-function parseOptsVideoStreams(optsVideoStream?: string) {
+const DEFAULT_AUDIO_TRACKS: AudioTracks[] = [
+  { language: "en", name: "English", default: true },
+]
+
+const CHANNEL_PRESETS = {
+  'ATMOS': {
+    video: [
+      { resolution: [640, 360], bw: 3663471, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+      { resolution: [1280, 720], bw: 5841380, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+      { resolution: [1920, 1080], bw: 8973571, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+
+      { resolution: [640, 360], bw: 4301519, codecs: "avc1.64001F,ec-3", channels: "16/JOC" },
+      { resolution: [1280, 720], bw: 6479428, codecs: "avc1.64001F,ec-3", channels: "16/JOC" },
+      { resolution: [1920, 1080], bw: 9611619, codecs: "avc1.640032,ec-3", channels: "16/JOC" },
+    ],
+    audio: [
+      { language: "en", name: "English", default: true },
+    ]
+  },
+  'DD': {
+    video: [
+      { resolution: [640, 360], bw: 3663471, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+      { resolution: [1280, 720], bw: 5841380, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+      { resolution: [1920, 1080], bw: 8973571, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+
+      { resolution: [640, 360], bw: 4301519, codecs: "avc1.64001F,ac-3", channels: "6" },
+      { resolution: [1280, 720], bw: 6479428, codecs: "avc1.64001F,ac-3", channels: "6" },
+      { resolution: [1920, 1080], bw: 9611619, codecs: "avc1.640032,ac-3", channels: "6" },
+    ],
+    audio: [
+      { language: "en", name: "English", default: true },
+    ]
+  },
+}
+
+function parseOptsVideoStreams(optsVideoStream?: string): ChannelProfile[] {
   if (!optsVideoStream) {
     return DEFAULT_VIDEO_STREAMS;
   }
@@ -32,24 +70,44 @@ function streamByHeight(streams, height: number) {
   return streams.find(r => r.resolution[1] === height);
 }
 
-export function getDefaultChannelVideoProfile() {
-  let streams = parseOptsVideoStreams(process.env.OPTS_VIDEO_STREAMS);
-  if (process.env.OPTS_STREAM_ORDER) {
-    let newStreams = [];
-    const streamOrder = process.env.OPTS_STREAM_ORDER.split(",");
-    for(const height of streamOrder) {
-      const stream = streamByHeight(streams, parseInt(height));
-      if (stream) {
-        newStreams.push(stream);
+export function getDefaultChannelVideoProfile(): ChannelProfile[] {
+  if (process.env.OPTS_CHANNEL_PRESET && CHANNEL_PRESETS[process.env.OPTS_CHANNEL_PRESET]) {
+    const videoProfile = CHANNEL_PRESETS[process.env.OPTS_CHANNEL_PRESET].video;
+    return videoProfile;
+  } else {
+    let streams = parseOptsVideoStreams(process.env.OPTS_VIDEO_STREAMS);
+    if (process.env.OPTS_STREAM_ORDER) {
+      let newStreams = [];
+      const streamOrder = process.env.OPTS_STREAM_ORDER.split(",");
+      for(const height of streamOrder) {
+        const stream = streamByHeight(streams, parseInt(height));
+        if (stream) {
+          newStreams.push(stream);
+        }
       }
+      streams = newStreams;
     }
-    streams = newStreams;
+    return streams;
   }
-  return streams;
 }
 
-export function getDefaultChannelAudioProfile() {
-  return [
-    { language: "en", name: "English", default: true }
-  ];
+export function getDefaultChannelAudioProfile(): AudioTracks[] {
+  const langList = process.env.OPTS_LANG_LIST;
+  if (langList) {
+    const audioTracks = [];
+    const languages = langList.split(",");
+    for (let i = 0; i < languages.length; i++) {
+      let lang: Language = {
+        language: languages[i],
+        name: languages[i],
+        default: (i === 0)
+      };
+      audioTracks.push(lang);
+    }
+    return audioTracks;
+  } else if (process.env.OPTS_CHANNEL_PRESET && CHANNEL_PRESETS[process.env.OPTS_CHANNEL_PRESET]) {
+    return CHANNEL_PRESETS[process.env.OPTS_CHANNEL_PRESET].audio;
+  } else {
+    return DEFAULT_AUDIO_TRACKS;
+  }
 }


### PR DESCRIPTION
This PR adds support for channel presets and advanced audio such as Dolby Atmos. Two new container options:

- `OPTS_LANG_LIST`: Comma separated list of languages, e.g. (`"en,ja"`). First one is defined to be default
- `OPTS_CHANNEL_PRESET`: Channel profile based on presets:
  - `DD`: Sterao (2) and Dolby Digital (6)
  - `ATMOS`: Stereo (2) and Dolby Atmos track (16) 