### PR TITLE
feat: plugin to produce barker channels

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,6 +15,7 @@ The following plugins are available.
 | ScheduleService | Fetches schedule and channels from an [Eyevinn Schedule Service](https://github.com/Eyevinn/schedule-service) |
 | Loop | Produce a channel with a single VOD on loop |
 | Playlist | Produce a channel based on a playlist txt file |
+| Barker | Produce a barker channel by switching between live channels a given interval |
 
 ## Demo Plugin Options
 
@@ -37,3 +38,9 @@ Channel with the HLS VOD to loop is then available at `/channels/loop/master.m3u
 - `PLAYLIST_CHANNEL_NAME`: The name of the channel (default `playlist`)
 
 To provide a set of playlists the `PLAYLIST_URL` is a comma separated list of channel name and playlist url pairs delimited by a pipe char (`|`): `PLAYLIST_URL="<CHANNEL_NAME1>|<URL1>,<CHANNEL_NAME2>|<URL2>"`. In this case the `PLAYLIST_CHANNEL_NAME` is overriden if set.
+
+## Barker Plugin Options
+
+- `BARKERLIST_URL`: URL to a txt file with list of live HLS streams where each line contains a URL to a HLS LIVE stream ([example](https://testcontent.eyevinn.technology/fast/barkertest.txt))
+- `BARKER_CHANNEL_NAME`: The name of the channel (default `barker`)
+- `SWITCH_INTERVAL_SEC`: How often it should switch between the streams (default 60 sec)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "eyevinn-channel-engine": "4.0.20",
         "finalhandler": "^1.2.0",
         "node-fetch": "^2.6.5",
-        "serve-static": "^1.15.0"
+        "serve-static": "^1.15.0",
+        "uuidv4": "^6.2.13"
       },
       "devDependencies": {
         "@types/jest": "^29.2.2",
@@ -1745,6 +1746,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -5451,6 +5457,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -6755,6 +6770,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/yargs": {
       "version": "17.0.13",
@@ -9460,6 +9480,15 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "requires": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
+      }
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eyevinn-channel-engine": "4.0.20",
     "finalhandler": "^1.2.0",
     "node-fetch": "^2.6.5",
-    "serve-static": "^1.15.0"
+    "serve-static": "^1.15.0",
+    "uuidv4": "^6.2.13"
   }
 }

--- a/src/plugin_factory.ts
+++ b/src/plugin_factory.ts
@@ -3,6 +3,7 @@ import { PluginInterface } from "./plugins/interface";
 import { ScheduleServicePlugin } from "./plugins/plugin_schedule_service";
 import { LoopPlugin } from "./plugins/plugin_loop";
 import { PlaylistPlugin } from "./plugins/plugin_playlist";
+import { BarkerPlugin } from "./plugins/plugin_barker";
 
 function create<T extends PluginInterface>(c: { new(): T }): T {
   return new c();  
@@ -18,6 +19,8 @@ export function PluginFactory(pluginName: string) {
       return create(LoopPlugin);
     case 'Playlist':
       return create(PlaylistPlugin);
+    case 'Barker':
+      return create(BarkerPlugin);
     default:
       throw new Error(`Plugin ${pluginName} is not available`);
   }

--- a/src/plugins/plugin_barker.ts
+++ b/src/plugins/plugin_barker.ts
@@ -1,0 +1,132 @@
+import { IAssetManager, IChannelManager, 
+  VodRequest, VodResponse, 
+  Channel, ChannelProfile, IStreamSwitchManager, Schedule 
+} from "eyevinn-channel-engine";
+import { ScheduleStreamType } from "eyevinn-channel-engine/dist/engine/server";
+import fetch from "node-fetch";
+import { BasePlugin, PluginInterface } from "./interface";
+
+import { generateId, getDefaultChannelAudioProfile, getDefaultChannelVideoProfile } from "./utils";
+
+class BarkerAssetManager implements IAssetManager {
+  private fallbackVodToLoop: URL;
+
+  constructor(fallbackVodToLoop: URL) {
+    this.fallbackVodToLoop = fallbackVodToLoop;
+  }
+
+  async getNextVod(vodRequest: VodRequest): Promise<VodResponse> {
+    const vodResponse = {
+      id: "loop",
+      title: "VOD on Loop",
+      uri: this.fallbackVodToLoop.toString(),
+    };
+    return vodResponse;
+  }
+}
+
+class BarkerChannelManager implements IChannelManager {
+  private channelId: string;
+  private useDemuxedAudio: boolean;
+
+  constructor(channelId: string, useDemuxedAudio: boolean = false) {
+    this.channelId = channelId;
+    this.useDemuxedAudio = useDemuxedAudio;
+    console.log(`Barker channel available at /channels/${this.channelId}/master.m3u8`);
+  }
+
+  getChannels(): Channel[] {
+    let channel: Channel = {
+      id: this.channelId,
+      profile: this._getProfile()
+    };
+    if (this.useDemuxedAudio) {
+      channel.audioTracks = getDefaultChannelAudioProfile()
+    }
+    const channelList = [ channel ];
+    return channelList;
+  }
+
+  _getProfile(): ChannelProfile[] {
+    return getDefaultChannelVideoProfile();
+  }  
+}
+
+class BarkerStreamSwitchManager implements IStreamSwitchManager {
+  private schedule: Schedule[] = [];
+  private liveStreams: URL[] = [];
+  private startOffset: number = -1;
+  private liveStreamListUrl: URL;
+  private switchIntervalMs: number = 60 * 1000;
+
+  constructor(liveStreamListUrl: URL, switchIntervalMs?: number) {
+    this.liveStreamListUrl = liveStreamListUrl;
+    this.switchIntervalMs = switchIntervalMs;
+  }
+
+  async getSchedule(channelId: string): Promise<Schedule[]> {
+    if (this.liveStreams.length === 0) {
+      console.log("Fetching live stream list from " + this.liveStreamListUrl.toString());
+      const response = await fetch(this.liveStreamListUrl.toString());
+      if (response.ok) {
+        const body = await response.text();
+        this.liveStreams = body.split(/\r?\n/).filter(l => l !== '').map(l => new URL(l.trim()));
+      }  
+    }
+
+    const streamDuration = this.switchIntervalMs;
+    const tsNow = Date.now();
+    if (this.startOffset === -1) {
+      this.startOffset = tsNow;
+    }
+
+    this.schedule = this.schedule.filter((obj) => obj.end_time >= tsNow);
+    if (this.schedule.length === 0) {
+      this.schedule.push({
+        eventId: generateId(),
+        assetId: generateId(),
+        title: 'Live source A',
+        type: ScheduleStreamType.LIVE,
+        start_time: this.startOffset,
+        end_time: this.startOffset + streamDuration,
+        uri: this.liveStreams[Math.floor(Math.random() * this.liveStreams.length)].toString(),
+      });
+      this.startOffset += streamDuration;
+      this.schedule.push({
+        eventId: generateId(),
+        assetId: generateId(),
+        title: 'Live source B',
+        type: ScheduleStreamType.LIVE,
+        start_time: this.startOffset,
+        end_time: this.startOffset + streamDuration,
+        uri: this.liveStreams[Math.floor(Math.random() * this.liveStreams.length)].toString(),
+      });
+      this.startOffset += streamDuration;
+    }
+    return this.schedule;
+  }
+}
+
+export class BarkerPlugin extends BasePlugin implements PluginInterface  {
+  constructor() {
+    super('Barker');
+  }
+  
+  newAssetManager(): IAssetManager {
+    const vodToLoop = new URL('https://lab.cdn.eyevinn.technology/sto-slate.mp4/manifest.m3u8');
+    return new BarkerAssetManager(vodToLoop);
+  }
+
+  newChannelManager(useDemuxedAudio: boolean): IChannelManager {
+    return new BarkerChannelManager(process.env.BARKER_CHANNEL_NAME ? process.env.BARKER_CHANNEL_NAME : "barker", useDemuxedAudio);
+  }
+
+  newStreamSwitchManager(): IStreamSwitchManager {
+    const liveStreamListUrl = process.env.BARKERLIST_URL ? 
+      process.env.BARKERLIST_URL 
+      : "https://testcontent.eyevinn.technology/fast/barkertest.txt";
+    const switchIntervalMs = process.env.SWITCH_INTERVAL_SEC ? parseInt(process.env.SWITCH_INTERVAL_SEC) * 1000 : undefined;
+
+    return new BarkerStreamSwitchManager(new URL(liveStreamListUrl), switchIntervalMs);
+  }
+}

--- a/src/plugins/utils.ts
+++ b/src/plugins/utils.ts
@@ -1,6 +1,8 @@
 import { AudioTracks, ChannelProfile } from "eyevinn-channel-engine";
 import { Language } from "./interface";
 
+import { uuid } from 'uuidv4';
+
 const DEFAULT_VIDEO_STREAMS: ChannelProfile[] = [
   { bw: 324586, codecs: "avc1.64000D,mp4a.40.2", resolution: [416, 234] },
   { bw: 471661, codecs: "avc1.64001E,mp4a.40.2", resolution: [640, 360] },
@@ -110,4 +112,8 @@ export function getDefaultChannelAudioProfile(): AudioTracks[] {
   } else {
     return DEFAULT_AUDIO_TRACKS;
   }
+}
+
+export function generateId(): string {
+  return uuid();
 }


### PR DESCRIPTION
Plugin `Barker` to produce a barker channel by switching between live channels a given interval

- `BARKERLIST_URL`: URL to a txt file with list of live HLS streams where each line contains a URL to a HLS LIVE stream ([example](https://testcontent.eyevinn.technology/fast/barkertest.txt))
- `BARKER_CHANNEL_NAME`: The name of the channel (default `barker`)
- `SWITCH_INTERVAL_SEC`: How often it should switch between the streams (default 60 sec)