### PR TITLE
feat: support for house ads insertion

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ The following environment variables can be set:
   - `ATMOS`: Stereo (2) and Dolby Atmos track (16)
   - `HEVC`: HEVC codec with stereo (2)
 - `OPTS_VTT_BASE_PATH`: Base path for vtt dummy and slice endpoints (default: `/vtt`)
+- `OPTS_STITCH_ENDPOINT`: [Stitch endpoint](https://github.com/Eyevinn/lambda-stitch) used for stitching prerolls in VODs
 
 ### Advanced Audio
 
@@ -122,6 +123,20 @@ docker run -p 8000:8000 \
   -e OPTS_CHANNEL_PRESET=ATMOS \
   -e OPTS_LANG_LIST=ja,en \
   eyevinntechnology/fast-engine
+```
+
+### Insert house ads for downstream SSAI ad replacement
+
+House ads can be inserted as preroll to each VOD and decorated with necessary HLS tags to allow downstream SSAI ad replacement and monetization.
+
+```
+docker run -p 8000:8000 \
+  -e FAST_PLUGIN=Playlist \
+  -e PLAYLIST_URL=https://testcontent.eyevinn.technology/fast/fastdemo.txt \
+  -e OPTS_USE_DEMUXED_AUDIO=false \
+  -e OPTS_STITCH_ENDPOINT=http://lambda.eyevinn.technology/stitch \
+  -e PLAYLIST_PREROLL_URL=https://lab.cdn.eyevinn.technology/sto-slate.mp4/manifest.m3u8 \
+  -e PLAYLIST_PREROLL_DURATION_MS=10000 npm start
 ```
 
 ### Multiview

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -30,6 +30,8 @@ The following plugins are available.
 
 - `LOOP_VOD_URL`: URL to the HLS VOD to loop.
 - `LOOP_CHANNEL_NAME`: The name of the channel (default `loop`)
+- `LOOP_PREROLL_URL`: URL for a preroll to insert before the HLS VOD
+- `LOOP_PREROLL_DURATION_MS`: Duration of preroll in milliseconds
 
 Channel with the HLS VOD to loop is then available at `/channels/loop/master.m3u8`
 
@@ -37,6 +39,8 @@ Channel with the HLS VOD to loop is then available at `/channels/loop/master.m3u
 
 - `PLAYLIST_URL`: URL to the playlist txt file. A txt file where each line contains a URL to a HLS VOD ([example](https://testcontent.eyevinn.technology/fast/fast-playlist.txt))
 - `PLAYLIST_CHANNEL_NAME`: The name of the channel (default `playlist`)
+- `PLAYLIST_PREROLL_URL`: URL for a preroll to insert before the HLS VOD
+- `PLAYLIST_PREROLL_DURATION_MS`: Duration of preroll in milliseconds
 
 To provide a set of playlists the `PLAYLIST_URL` is a comma separated list of channel name and playlist url pairs delimited by a pipe char (`|`): `PLAYLIST_URL="<CHANNEL_NAME1>|<URL1>,<CHANNEL_NAME2>|<URL2>"`. In this case the `PLAYLIST_CHANNEL_NAME` is overriden if set.
 

--- a/docs/plugins/webhook.md
+++ b/docs/plugins/webhook.md
@@ -12,6 +12,10 @@ interface NextVodResponse {
   id: string;
   title: string;
   hlsUrl: string;
+  prerollUrl?: string;
+  prerollDurationMs?: number;
+  desiredOffsetMs?: number;
+  desiredDurationMs?: number;
 }
 
 interface NextVodQuerystring {

--- a/src/plugins/interface.ts
+++ b/src/plugins/interface.ts
@@ -30,3 +30,14 @@ export interface Language {
   name: string;
   default: boolean;
 }
+
+export interface StitchPayloadBreak {
+  pos: number; // ms
+  duration: number; // ms
+  url: string;
+}
+
+export interface StitchPayload {
+  uri: string;
+  breaks: StitchPayloadBreak[];
+}

--- a/src/plugins/utils.ts
+++ b/src/plugins/utils.ts
@@ -3,7 +3,7 @@ import {
   ChannelProfile,
   SubtitleTracks
 } from 'eyevinn-channel-engine';
-import { Language } from './interface';
+import { Language, StitchPayload } from './interface';
 
 import { uuid } from 'uuidv4';
 
@@ -228,4 +228,34 @@ export function getDefaultChannelSubtitleProfile(): SubtitleTracks[] {
 
 export function generateId(): string {
   return uuid();
+}
+
+function serialize<T>(payload: T) {
+  const buff = Buffer.from(JSON.stringify(payload));
+  return buff.toString('base64');
+}
+
+export function getVodUrlWithPreroll(
+  url: string,
+  prerollUrl: string,
+  prerollDurationMs: number
+): string {
+  if (process.env.OPTS_STITCH_ENDPOINT) {
+    const payload: StitchPayload = {
+      uri: url,
+      breaks: [
+        {
+          pos: 0,
+          duration: prerollDurationMs,
+          url: prerollUrl
+        }
+      ]
+    };
+    return (
+      process.env.OPTS_STITCH_ENDPOINT +
+      `/master.m3u8?payload=` +
+      serialize<StitchPayload>(payload)
+    );
+  }
+  return url;
 }


### PR DESCRIPTION
House ads can be inserted as preroll to each VOD and decorated with necessary HLS tags to allow downstream SSAI ad replacement and monetization. In addition webhook interface has been extended with preroll URL and option to set a duration and start offset of the VOD.