### PR TITLE
feat: latest version of CE including features and bugfixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ To produce a channel based on a txt file with a list of VOD URLs:
 docker run -d -p 8000:8000 \
   -e FAST_PLUGIN=Playlist \
   -e PLAYLIST_URL=https://testcontent.eyevinn.technology/fast/fast-playlist.txt \
+  -e OPTS_USE_DEMUXED_AUDIO=false \
   eyevinntechnology/fast-engine
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/schedule-service-adapter": "^0.4.1",
-        "eyevinn-channel-engine": "4.2.12",
+        "eyevinn-channel-engine": "4.3.11",
         "finalhandler": "^1.2.0",
         "node-fetch": "^2.6.5",
         "serve-static": "^1.15.0",
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-3.1.2.tgz",
-      "integrity": "sha512-VJkZqyPVLmTFcRjePQyaRJzRKGVD/Sr0eVnPz8SndbRtk5s3Qiia83dAII9SjdK8vyFopwdjWxSFnftghSp+5g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.1.tgz",
+      "integrity": "sha512-TgAwYSwNYh6nPHxBKMPsS3DFAfVUO2vbbCB9r7sRvxOTEn6qIaNMOgL2fYl+OQjXG9gJAMrcFOTRMUDvQZ/HpQ==",
       "dependencies": {
         "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
@@ -1052,6 +1052,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4208,6 +4213,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5361,16 +5374,17 @@
       ]
     },
     "node_modules/eyevinn-channel-engine": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.2.12.tgz",
-      "integrity": "sha512-EKQX2622T64j19jkX1gQIXJpecFbbCAqAXqX5Ap7d/HrncZW1ETNH8AP52wzyKfmcLREWD0rY6LeP3aJR4AZNg==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.3.11.tgz",
+      "integrity": "sha512-l/m6DltujNPVKInOt9Mq7jXhpnUt0ErnyOm42DN3VeF7hrEadRPwqAIBq0Z9HzPE/uuZLn8rDuRGXvkaQOacGw==",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.3.0",
-        "@eyevinn/hls-vodtolive": "^3.1.2",
+        "@eyevinn/hls-vodtolive": "^4.1.1",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
+        "ioredis": "^5.3.2",
         "memcache-client": "^0.10.1",
         "nock": "^13.1.1",
         "node-fetch": "^2.6.1",
@@ -6280,6 +6294,58 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -7719,6 +7785,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -9652,6 +9723,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -11123,9 +11199,9 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-3.1.2.tgz",
-      "integrity": "sha512-VJkZqyPVLmTFcRjePQyaRJzRKGVD/Sr0eVnPz8SndbRtk5s3Qiia83dAII9SjdK8vyFopwdjWxSFnftghSp+5g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.1.tgz",
+      "integrity": "sha512-TgAwYSwNYh6nPHxBKMPsS3DFAfVUO2vbbCB9r7sRvxOTEn6qIaNMOgL2fYl+OQjXG9gJAMrcFOTRMUDvQZ/HpQ==",
       "requires": {
         "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
@@ -11280,6 +11356,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -13486,6 +13567,11 @@
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -14338,16 +14424,17 @@
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
     "eyevinn-channel-engine": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.2.12.tgz",
-      "integrity": "sha512-EKQX2622T64j19jkX1gQIXJpecFbbCAqAXqX5Ap7d/HrncZW1ETNH8AP52wzyKfmcLREWD0rY6LeP3aJR4AZNg==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/eyevinn-channel-engine/-/eyevinn-channel-engine-4.3.11.tgz",
+      "integrity": "sha512-l/m6DltujNPVKInOt9Mq7jXhpnUt0ErnyOm42DN3VeF7hrEadRPwqAIBq0Z9HzPE/uuZLn8rDuRGXvkaQOacGw==",
       "requires": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.3.0",
-        "@eyevinn/hls-vodtolive": "^3.1.2",
+        "@eyevinn/hls-vodtolive": "^4.1.1",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
+        "ioredis": "^5.3.2",
         "memcache-client": "^0.10.1",
         "nock": "^13.1.1",
         "node-fetch": "^2.6.1",
@@ -15018,6 +15105,42 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "denque": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "ipaddr.js": {
@@ -16038,6 +16161,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -17470,6 +17598,11 @@
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@eyevinn/schedule-service-adapter": "^0.4.1",
-    "eyevinn-channel-engine": "4.2.12",
+    "eyevinn-channel-engine": "4.3.11",
     "finalhandler": "^1.2.0",
     "node-fetch": "^2.6.5",
     "serve-static": "^1.15.0",


### PR DESCRIPTION
Update Channel Engine from 4.2.12 to 4.3.11:

## New Features
- feat: Add Reset by Channel feature
- feat: enable io ops logging for Redis
- feat: option to set keep alive timeout 
- feat: option to protect session health endpoint with a key

## Bugfixes
- fix: timeOffset - Once enabled, Forever 
- fix: Missing Newlines in Dummy Webvtt Response 
- fix: performance bottlenecks when running in High Availability mode with Redis. Changed to use [ioredis](https://github.com/redis/ioredis) as Redis client and implemented pipelining of operations. This greatly reduces the amount of round-trips and packet congestion to keep the playhead and session states in synch.
- fix: Disable Eventstream by Default 
- fix: HA & Demux - Audio Increment Not Respecting Position Diff-Threshold 
- fix: Subtitle Track Playhead is dependant Of Video Track
- fix: Wrong Audio M3U8 When Request Is Mid-Loading Next Vod
- fix: add subtitle media sequence data to insertSlate fn