### PR TITLE
feat: add optional bumperUrl/bumperDurationMs to WebHookNextVodResponse

### DIFF
--- a/docs/plugins/webhook.md
+++ b/docs/plugins/webhook.md
@@ -14,6 +14,8 @@ interface NextVodResponse {
   hlsUrl: string;
   prerollUrl?: string;
   prerollDurationMs?: number;
+  bumperUrl?: string;
+  bumperDurationMs?: number;
   desiredOffsetMs?: number;
   desiredDurationMs?: number;
 }
@@ -59,3 +61,18 @@ docker run -d -p 8000:8000 \
 ```
 
 You are then good to go using a custom webhook to control what should be played up next in the channel available at: http://localhost:8000/channels/mychannel/master.m3u8
+
+## Response fields
+
+| Field               | Type      | Description                                           |
+| ------------------- | --------- | ----------------------------------------------------- |
+| `id`                | `string`  | Unique identifier of the VOD.                         |
+| `title`             | `string`  | Title of the VOD.                                     |
+| `hlsUrl`            | `string`  | URL to the HLS manifest of the VOD to play next.      |
+| `type`              | `string`  | Set to `gap` to insert a gap, otherwise omit.         |
+| `prerollUrl`        | `string?` | Optional URL to a preroll to prepend before the VOD.  |
+| `prerollDurationMs` | `number?` | Optional duration of the preroll in milliseconds.     |
+| `bumperUrl`         | `string?` | Optional URL to a bumper associated with the VOD.     |
+| `bumperDurationMs`  | `number?` | Optional duration of the bumper in milliseconds.      |
+| `desiredOffsetMs`   | `number?` | Optional start offset into the VOD in milliseconds.   |
+| `desiredDurationMs` | `number?` | Optional desired duration of the VOD in milliseconds. |

--- a/src/plugins/plugin_webhook.test.ts
+++ b/src/plugins/plugin_webhook.test.ts
@@ -67,6 +67,28 @@ describe('webhook plugin', () => {
     }
   });
 
+  test('parses response containing bumper fields without error', async () => {
+    fetchMock.mockResponse(
+      JSON.stringify({
+        hlsUrl: 'https://vod.dummy/foo.m3u8',
+        id: 'dummy',
+        title: 'dummytitle',
+        bumperUrl: 'https://vod.dummy/bumper.m3u8',
+        bumperDurationMs: 5000
+      })
+    );
+
+    const plugin = new WebHookPlugin();
+    const assetManager = plugin.newAssetManager();
+    const nextVod = await assetManager.getNextVod({
+      sessionId: 'dummy',
+      playlistId: 'test'
+    });
+    expect(nextVod.uri).toEqual('https://vod.dummy/foo.m3u8');
+    expect(nextVod.id).toEqual('dummy');
+    expect(nextVod.title).toEqual('dummytitle');
+  });
+
   test('does not provides apikey on http request if not enabled', async () => {
     process.env.OPTS_WEBHOOK_APIKEY = undefined;
 

--- a/src/plugins/plugin_webhook.ts
+++ b/src/plugins/plugin_webhook.ts
@@ -25,6 +25,8 @@ export interface WebHookNextVodResponse {
   type: string; // 'gap' or null
   prerollUrl?: string;
   prerollDurationMs?: number;
+  bumperUrl?: string;
+  bumperDurationMs?: number;
   desiredOffsetMs?: number;
   desiredDurationMs?: number;
 }
@@ -60,6 +62,16 @@ class WebHookAssetManager implements IAssetManager {
           hlsUrl,
           payload.prerollUrl,
           payload.prerollDurationMs
+        );
+      }
+      // Optional bumper fields are parsed here for forward-compatibility.
+      // Stitching the bumper into the VOD payload is handled by a separate
+      // (currently blocked) change, so we only read them for now.
+      const bumperUrl = payload.bumperUrl;
+      const bumperDurationMs = payload.bumperDurationMs;
+      if (bumperUrl && bumperDurationMs) {
+        console.log(
+          `Received bumper ${bumperUrl} (${bumperDurationMs}ms) from webhook`
         );
       }
       const vodResponse: VodResponse = {


### PR DESCRIPTION
## Summary
- Implements #66: a safe, independent typing change adding optional bumper fields to the webhook response interface, unblocking downstream stitch work.

## Changes
- `src/plugins/plugin_webhook.ts`: add optional `bumperUrl?: string` and `bumperDurationMs?: number` to `WebHookNextVodResponse` (existing `type`/preroll fields preserved); parse them in `getNextVod`. No stitch-payload wiring (that is the separate blocked issue #67).
- `docs/plugins/webhook.md`: document the new fields.
- `src/plugins/plugin_webhook.test.ts`: cover a response with the new fields being parsed without error.

## Test plan
- PROOF: `npm run lint` clean; `npm run pretty` clean (formatted the touched doc); `npm test` → Test Suites: 1 passed, Tests: 4 passed.

Closes #66

🤖 Automated via Channel Engine Dev daily-backlog-pr skill