### PR TITLE
chore: add grouped npm dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Implements #69 (split from #68): add a repo-level `.github/dependabot.yml` grouping npm minor/patch bumps so the dependabot queue stops accumulating one-PR-per-bump.

## Changes
- `.github/dependabot.yml`: npm ecosystem at `/`, weekly schedule, `open-pull-requests-limit: 10`, `npm-minor-patch` group covering minor + patch. Major bumps intentionally stay ungrouped/individually reviewable.

## Scope
- Config-only, no runtime change. Does not touch the 7 existing open dependabot PRs (the next scheduled run supersedes grouped ones). Auto-merge policy is the separate decision issue #70.

## Test plan
- PROOF: YAML parses successfully (structure matches spec). `npm run pretty` clean. eslint/jest do not cover `.github/*.yml`, so they are not meaningful gates for this config-only change.

Closes #69

🤖 Automated via Channel Engine Dev daily-backlog-pr skill